### PR TITLE
Disable xpack security component by default

### DIFF
--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -12,3 +12,5 @@ path.data: /data
 network.host: 0.0.0.0
 
 discovery.zen.minimum_master_nodes: ${MINIMUM_MASTER_NODES}
+
+xpack.security.enabled: ${XPACK_SECURITY_ENABLED}

--- a/run.sh
+++ b/run.sh
@@ -7,6 +7,7 @@ export NODE_DATA=${NODE_DATA:-true}
 export HTTP_PORT=${HTTP_PORT:-9200}
 export TRANSPORT_PORT=${TRANSPORT_PORT:-9300}
 export MINIMUM_MASTER_NODES=${MINIMUM_MASTER_NODES:-2}
+export XPACK_SECURITY_ENABLED=${XPACK_SECURITY_ENABLED:-false}
 
 chown -R elasticsearch:elasticsearch /data
 


### PR DESCRIPTION
 X-Pack has a 30 day trial license to allow access to all features, see:
https://www.elastic.co/guide/en/x-pack/current/license-management.html

The X-Pack security component prevents the usage of Kibana after 30 days.

This PR disables the X-Pack security component by default.